### PR TITLE
Explicitly enabling paused shows to be displayed...

### DIFF
--- a/app/src/main/java/com/mgaetan89/showsrage/network/SickRageServices.java
+++ b/app/src/main/java/com/mgaetan89/showsrage/network/SickRageServices.java
@@ -64,7 +64,7 @@ public interface SickRageServices {
 	@GET("/{api_path}/{api_key}/?cmd=show")
 	void getShow(@Query("indexerid") int indexerId, Callback<SingleShow> callback);
 
-	@GET("/{api_path}/{api_key}/?cmd=shows&sort=name")
+	@GET("/{api_path}/{api_key}/?cmd=shows&sort=name&paused=1")
 	void getShows(Callback<Shows> callback);
 
 	@GET("/{api_path}/{api_key}/?cmd=shows.stats")


### PR DESCRIPTION
Due to a change in SickRage's API (was a bug fix, the current functionality is working as intended), shows that are in a paused state do not display on an API call unless "paused=true" is included. This has always been the documented behaviour, but alas, paused shows were included even with the paused=true attribute omitted. This PR restores the functionality prior to the API bug fix being implemented in SickRage.

There's also discussion within the SickRage team to consider turning this into a trinary value: both paused and unpaused, unpaused only, or paused only. In that case, perhaps an Interface setting could be added to let the user specify the required behaviour of this attribute.
